### PR TITLE
[FIX] requirements.txt: Freezing mysqlclient version to 2.0.1 as more recent 2.0.2 (#100)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 sqlalchemy
-mysqlclient
+mysqlclient==2.0.1
 pymssql<3.0


### PR DESCRIPTION


makes the CI to fail

Cherry-pick of https://github.com/OCA/server-backend/commit/7703f14cff3a50a3ce4f0944f3753968d1f7c9bc